### PR TITLE
Fix reconnection

### DIFF
--- a/pgpemu-esp32/main/pgpemu.c
+++ b/pgpemu-esp32/main/pgpemu.c
@@ -567,6 +567,7 @@ void handle_protocol(esp_gatt_if_t gatts_if,
 				    sizeof(notify_data), notify_data, false);
 			cert_state = 4;
 		}
+		break;
         }
 	case 4:
         {


### PR DESCRIPTION
Due to missing break statement between state 3 a 4, reconnection is not handled correctly after refactoring done in 000676d.